### PR TITLE
Add Czech first row

### DIFF
--- a/src/main/kotlin/com/dekonoplyov/Predefined.kt
+++ b/src/main/kotlin/com/dekonoplyov/Predefined.kt
@@ -48,6 +48,16 @@ private const val CZECH = """; with ů
 \ with ¨
 ] with )
 ' with §
+1 with +
+2 with ě
+3 with š
+4 with č
+5 with ř
+6 with ž
+7 with ý
+8 with á
+9 with í
+0 with é
 """
 
 private const val OTHER = """; with ;


### PR DESCRIPTION
Hey, thanks for the plugin. For the Czech layout, the biggest problem is the first row, which cannot be used for focusing tool windows as numbers are redefined and must be pressed with shift. This patch solves this.